### PR TITLE
gluster_hci : variable name fix

### DIFF
--- a/roles/gluster_hci/README.md
+++ b/roles/gluster_hci/README.md
@@ -33,7 +33,7 @@ detailed playbooks.
 ```
 - name: Setting up GlusterFS HCI
   remote_user: root
-  hosts: gluster_hci
+  hosts: hc-nodes
   gather_facts: false
 
   vars:


### PR DESCRIPTION
variable name of hosts fix in README.md of gluster_hci.