### PR TITLE
Remove granular-entry-heal from the option

### DIFF
--- a/gluster-ansible-features.spec
+++ b/gluster-ansible-features.spec
@@ -2,8 +2,8 @@
 %global docdir %{_datadir}/doc/gluster.features
 
 Name:      gluster-ansible-features
-Version:   0.2
-Release:   1%{?dist}
+Version:   0.3
+Release:   1
 Summary:   Ansible roles for GlusterFS infrastructure management
 
 URL:       https://github.com/gluster/gluster-ansible-features
@@ -38,6 +38,9 @@ cp -dpr README.md examples %{buildroot}/%{docdir}
 %license LICENSE
 
 %changelog
+* Thu Sep 27 2018 Sachidananda Urs <sac@redhat.com> 0.3
+- Embed gluster_volume module within role
+
 * Fri Aug 31 2018 Sachidananda Urs <sac@redhat.com> 0.2
 - Disabled geo-replication for the initial release
 

--- a/roles/gluster_hci/defaults/main.yml
+++ b/roles/gluster_hci/defaults/main.yml
@@ -14,8 +14,7 @@ gluster_features_hci_volume_options:
      storage.owner-gid: '36',
      network.ping-timeout: '30',
      performance.strict-o-direct: 'on',
-     network.remote-dio: 'off',
-     cluster.granular-entry-heal: 'enable'
+     network.remote-dio: 'off'
    }
 
 gluster_features_hci_hookscripts:


### PR DESCRIPTION
granular-entry-heal will be set as separate option in the playbook.