### PR TITLE
ctdb: make enabling ctdb hook scripts configurable

### DIFF
--- a/examples/ctdb-setup.yml
+++ b/examples/ctdb-setup.yml
@@ -8,6 +8,7 @@
     gluster_features_ctdb_nodes: 192.168.1.1,192.168.2.5
     gluster_features_ctdb_publicaddr: '10.70.37.6/24 eth0,10.70.37.8/24 eth0'
     gluster_features_ctdb_volume: samba
+    gluster_features_ctdb_enable_hook_scripts: true
     ctdb_packages:
 
   roles:

--- a/roles/ctdb/README.md
+++ b/roles/ctdb/README.md
@@ -19,6 +19,7 @@ Role Variables
 | gluster_features_ctdb_volume |    | UNDEF | GlusterFS volumename to configure with CTDB|
 | gluster_features_ctdb_nodes  |  | UNDEF | Comma separated list of IP addresses  |
 | gluster_features_ctdb_publicaddr | | UNDEF | Comma separated list of public addresses with interface. For eg: 10.70.37.6/24 eth0,10.70.37.8/24 eth0|
+| gluster_features_ctdb_enable_hook_scripts | true/false | true | Enable the hook scripts to stop/start ctdb |
 | gluster_features_smb_username | | UNDEF | Samba username |
 | gluster_features_smb_password | | UNDEF | Samba password. Note that password variable has to be encrypted using ansible-vault |
 

--- a/roles/ctdb/tasks/setup_ctdb.yml
+++ b/roles/ctdb/tasks/setup_ctdb.yml
@@ -61,6 +61,8 @@
       - /var/lib/glusterd/hooks/1/stop/pre/S29CTDB-teardown.sh
       - /var/lib/glusterd/hooks/1/start/post/S29CTDBsetup.sh
   ignore_errors: yes
+  when: >
+    gluster_features_ctdb_enable_hook_scripts | default(true)
 
 # Restart the GlusterFS volume
 - name: Stop GlusterFS volume


### PR DESCRIPTION
It is not always desirable to have the ctdb hook scripts start/stop
the ctdb service and fiddle with the fstab for the lock volume.
This patch introduces a variable
gluster_features_ctdb_enable_hook_script defaulting to true which
can be set to false to disable the enablement of the hook scripts.

Signed-off-by: Michael Adam <obnox@samba.org>